### PR TITLE
Laravel 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In your `composer.json` file:
 ```json
 {
     "require": {
-        "laravel/framework": "4.0.*",
+        "laravel/framework": "5.0.*",
         // ...
         "felixkiss/uniquewith-validator": "1.1.*"
     }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# unique_with Validator Rule For Laravel 4
+# unique_with Validator Rule For Laravel 5
 
 [![Build Status](https://travis-ci.org/felixkiss/uniquewith-validator.png?branch=master)](https://travis-ci.org/felixkiss/uniquewith-validator)
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,30 @@
-# unique_with Validator Rule For Laravel 5
+# unique_with Validator Rule For Laravel
 
 [![Build Status](https://travis-ci.org/felixkiss/uniquewith-validator.png?branch=master)](https://travis-ci.org/felixkiss/uniquewith-validator)
 
-This package contains a variant of the `validateUnique` rule for Laravel 4, that allows for validation of multi-column UNIQUE indexes.
+This package contains a variant of the `validateUnique` rule for Laravel, that allows for validation of multi-column UNIQUE indexes.
 
 ## Installation
 
 Install the package through [Composer](http://getcomposer.org).
 
-In your `composer.json` file:
+### Laravel 4
 
-```json
-{
-    "require": {
-        "laravel/framework": "5.0.*",
-        // ...
-        "felixkiss/uniquewith-validator": "1.1.*"
-    }
-}
+On the command line:
+
+```
+composer require felixkiss/uniquewith-validator:1.*
 ```
 
-Run `composer install` or `composer update` to install the package.
+### Laravel 5
+
+On the command line:
+
+```
+composer require felixkiss/uniquewith-validator:2.*
+```
+
+## Configuration
 
 Add the following to your `providers` array in `config/app.php`:
 
@@ -42,7 +46,7 @@ $rules = array(
 );
 ```
 
-See the [Validation documentation](http://laravel.com/docs/validation) of Laravel 4.
+See the [Validation documentation](http://laravel.com/docs/validation) of Laravel.
 
 ### Specify different column names in the database
 
@@ -55,7 +59,6 @@ $rules = array(
     'first_name' => 'unique_with:users, middle_name, last_name = sur_name',
 );
 ```
-
 
 ## Example
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
         "illuminate/support": "5.x",
         "illuminate/validation": "5.x"
     },
@@ -23,5 +22,5 @@
             "Felixkiss\\UniqueWithValidator\\": "src/"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "stable"
 }

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.x",
-        "illuminate/validation": "4.x"
+        "illuminate/support": "5.x",
+        "illuminate/validation": "5.x"
     },
     "require-dev": {
         "mockery/mockery": "dev-master"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "felixkiss/uniquewith-validator",
-    "description": "Custom Laravel 4 Validator for combined unique indexes",
+    "description": "Custom Laravel 5 Validator for combined unique indexes",
     "keywords": ["laravel"],
     "homepage": "https://github.com/felixkiss/uniquewith-validator",
     "license": "MIT",
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "illuminate/support": "5.x",
         "illuminate/validation": "5.x"
     },
@@ -20,7 +20,7 @@
     },
     "autoload": {
         "psr-0": {
-            "Felixkiss\\UniqueWithValidator": "src/"
+            "Felixkiss\\UniqueWithValidator\\": "src/"
         }
     },
     "minimum-stability": "dev"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "felixkiss/uniquewith-validator",
-    "description": "Custom Laravel 5 Validator for combined unique indexes",
+    "description": "Custom Laravel Validator for combined unique indexes",
     "keywords": ["laravel"],
     "homepage": "https://github.com/felixkiss/uniquewith-validator",
     "license": "MIT",
@@ -11,6 +11,7 @@
         }
     ],
     "require": {
+        "php": ">=5.4.0",
         "illuminate/support": "5.x",
         "illuminate/validation": "5.x"
     },

--- a/src/Felixkiss/UniqueWithValidator/UniqueWithValidatorServiceProvider.php
+++ b/src/Felixkiss/UniqueWithValidator/UniqueWithValidatorServiceProvider.php
@@ -18,19 +18,23 @@ class UniqueWithValidatorServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //$this->package('felixkiss/uniquewith-validator');
-        $this->loadTranslationsFrom(__DIR__.'/../../lang', 'uniquewith-validator');
+        $this->loadTranslationsFrom(
+            __DIR__ . '/../../lang',
+            'uniquewith-validator'
+        );
 
         // Registering the validator extension with the validator factory
-        $this->app['validator']->resolver(function($translator, $data, $rules, $messages)
-        {
-            return new ValidatorExtension(
-                $translator,
-                $data,
-                $rules,
-                $messages
-            );
-        });
+        $this->app['validator']->resolver(
+            function($translator, $data, $rules, $messages)
+            {
+                return new ValidatorExtension(
+                    $translator,
+                    $data,
+                    $rules,
+                    $messages
+                );
+            }
+        );
     }
 
     /**

--- a/src/Felixkiss/UniqueWithValidator/UniqueWithValidatorServiceProvider.php
+++ b/src/Felixkiss/UniqueWithValidator/UniqueWithValidatorServiceProvider.php
@@ -1,7 +1,6 @@
 <?php namespace Felixkiss\UniqueWithValidator;
 
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Validation\Factory;
 
 class UniqueWithValidatorServiceProvider extends ServiceProvider
 {
@@ -19,7 +18,8 @@ class UniqueWithValidatorServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->package('felixkiss/uniquewith-validator');
+        //$this->package('felixkiss/uniquewith-validator');
+        $this->loadTranslationsFrom(__DIR__.'/../../lang', 'uniquewith-validator');
 
         // Registering the validator extension with the validator factory
         $this->app['validator']->resolver(function($translator, $data, $rules, $messages)


### PR DESCRIPTION
Adds some additional changes to #26:

 - Remove PHP 5.3 for Travis
 - Remove explicit references to Laravel 4 throughout the repo
 - Installation instruction for Laravel 4 and 5 in README
 - Minor formatting updates