### PR TITLE
Fix dot notation for array validation

### DIFF
--- a/src/Felixkiss/UniqueWithValidator/ValidatorExtension.php
+++ b/src/Felixkiss/UniqueWithValidator/ValidatorExtension.php
@@ -40,7 +40,13 @@ class ValidatorExtension extends Validator
         // needs to be verified as unique. If this parameter isn't specified
         // we will just assume that this column to be verified shares the
         // attribute's name.
-        $column = $attribute;
+
+        if (strpos($attribute, '.')) {
+            $exploded = explode('.', $attribute);
+            $column = array_pop($exploded);
+        } else {
+            $column = $attribute;
+        }
 
         // Create $extra array with all other columns, so getCount() will
         // include them as where clauses as well


### PR DESCRIPTION
Laravel 5 allows dot notation for supplying rules to the validator. 

`["customer.email" => "required|email|unique_with:users,something_id"]`

However this throws an error saying the field 'customer.email' cannot be found on the table users.

This fix just pops the last . separated variable off and uses that as the attribute.
