### PR TITLE
Pass customAttributes to constructor

### DIFF
--- a/src/Felixkiss/UniqueWithValidator/UniqueWithValidatorServiceProvider.php
+++ b/src/Felixkiss/UniqueWithValidator/UniqueWithValidatorServiceProvider.php
@@ -25,13 +25,14 @@ class UniqueWithValidatorServiceProvider extends ServiceProvider
 
         // Registering the validator extension with the validator factory
         $this->app['validator']->resolver(
-            function($translator, $data, $rules, $messages)
+            function($translator, $data, $rules, $messages, $customAttributes = array())
             {
                 return new ValidatorExtension(
                     $translator,
                     $data,
                     $rules,
-                    $messages
+                    $messages,
+                    $customAttributes
                 );
             }
         );


### PR DESCRIPTION
This fixes a problem where custom attributes specified to Validator::make()
were no longer available to any validator after installing the unique_with
validator in Laravel 4.2