### PR TITLE
Revert "Make service provider deferred"

### DIFF
--- a/src/Felixkiss/UniqueWithValidator/UniqueWithValidatorServiceProvider.php
+++ b/src/Felixkiss/UniqueWithValidator/UniqueWithValidatorServiceProvider.php
@@ -9,7 +9,7 @@ class UniqueWithValidatorServiceProvider extends ServiceProvider
      *
      * @var bool
      */
-    protected $defer = true;
+    protected $defer = false;
 
     /**
      * Bootstrap the application events.
@@ -55,6 +55,6 @@ class UniqueWithValidatorServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return array('validator');
+        return array();
     }
 }


### PR DESCRIPTION
This reverts commit 3918b0c987b4545c414eba988b66dba1d1de5e57.

Service providers with a boot method cannot be deferred! It's a mystery
to me that this worked in Laravel 5.1.

This fixes #50 but intentionally regresses #18. I don't think there's
any way to make this service deferred; Laravel exposes no events to hook
into the loading process of the validator, so we need to eagerly load
and register the validator.