### PR TITLE
Fixed bug where it was not possible to specify the connection to use

### DIFF
--- a/src/Felixkiss/UniqueWithValidator/ValidatorExtension.php
+++ b/src/Felixkiss/UniqueWithValidator/ValidatorExtension.php
@@ -1,5 +1,6 @@
 <?php namespace Felixkiss\UniqueWithValidator;
 
+use Illuminate\Support\Str;
 use Illuminate\Validation\Validator;
 
 class ValidatorExtension extends Validator
@@ -146,5 +147,20 @@ class ValidatorExtension extends Validator
         array_pop($parameters);
 
         return array($ignoreId, $ignoreColumn);
+    }
+
+    /**
+     * Parse the connection / table for the unique / exists rules.
+     *
+     * @param  string  $table
+     * @return array
+     */
+    protected function parseTable($table)
+    {
+        if (method_exists(get_parent_class($this), 'parseTable')) {
+            return parent::parseTable($table);
+        }
+
+        return Str::contains($table, '.') ? explode('.', $table, 2) : [null, $table];
     }
 }

--- a/src/Felixkiss/UniqueWithValidator/ValidatorExtension.php
+++ b/src/Felixkiss/UniqueWithValidator/ValidatorExtension.php
@@ -34,7 +34,7 @@ class ValidatorExtension extends Validator
         $parameters = array_map('trim', $parameters);
 
         // first item equals table name
-        $table = array_shift($parameters);
+        list($connection, $table) = $this->parseTable(array_shift($parameters));
 
         // The second parameter position holds the name of the column that
         // needs to be verified as unique. If this parameter isn't specified
@@ -90,6 +90,7 @@ class ValidatorExtension extends Validator
         // permanent data store like Redis, etc. We will use it to determine
         // uniqueness.
         $verifier = $this->getPresenceVerifier();
+        $verifier->setConnection($connection);
 
         return $verifier->getCount(
             $table,

--- a/tests/UniqueWithValidator/ValidatorExtensionTest.php
+++ b/tests/UniqueWithValidator/ValidatorExtensionTest.php
@@ -19,6 +19,8 @@ class ValidatorExtensionTest extends PHPUnit_Framework_TestCase
             ->andReturn($this->testDefaultErrorMessage);
         $this->translator->shouldReceive('trans')
             ->andReturnUsing(function($arg) { return $arg; });
+        $this->translator->shouldReceive('get')
+            ->andReturnUsing(function($arg) { return $arg; });
 
         $this->rules = array(
             'first_name' => 'unique_with:users,last_name',

--- a/tests/UniqueWithValidator/ValidatorExtensionTest.php
+++ b/tests/UniqueWithValidator/ValidatorExtensionTest.php
@@ -25,6 +25,7 @@ class ValidatorExtensionTest extends PHPUnit_Framework_TestCase
         );
 
         $this->presenceVerifier = Mockery::mock('Illuminate\Validation\PresenceVerifierInterface');
+        $this->presenceVerifier->shouldReceive('setConnection')->zeroOrMoreTimes();
 
         $this->messages = array();
     }


### PR DESCRIPTION
See issue #62 
I added possibility to specify the connection (same as in core \Illuminate\Validation\Validator::validateUnique() method)