### PR TITLE
Add support for Laravel's dot validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 7.1
   - hhvm
 env:
-  - LARAVEL_VERSION=5.0
   - LARAVEL_VERSION=5.2
   - LARAVEL_VERSION=5.3
   - LARAVEL_VERSION=5.4

--- a/spec/Felixkiss/UniqueWithValidator/RuleParserSpec.php
+++ b/spec/Felixkiss/UniqueWithValidator/RuleParserSpec.php
@@ -99,6 +99,58 @@ class RuleParserSpec extends ObjectBehavior
         $this->getAdditionalFields()->shouldReturn(['last_name' => 'Bar']);
     }
 
+    function it_can_parse_dot_notation_for_first_entry_of_array_correctly()
+    {
+        $this->beConstructedWith('users.0.first', 'Foo', ['users', 'users.*.first = first_name', 'users.*.last = last_name'], [
+            'users' => [
+                [
+                    'first' => 'Foo',
+                    'last' => 'Bar',
+                ],
+                [
+                    'first' => 'Baz',
+                    'last' => 'Quux',
+                ],
+            ],
+        ]);
+        $this->getPrimaryField()->shouldReturn('first_name');
+        $this->getAdditionalFields()->shouldReturn(['last_name' => 'Bar']);
+    }
+
+    function it_can_parse_dot_notation_for_second_entry_of_array_correctly()
+    {
+        $this->beConstructedWith('users.1.first', 'Baz', ['users', 'users.*.first = first_name', 'users.*.last = last_name'], [
+            'users' => [
+                [
+                    'first' => 'Foo',
+                    'last' => 'Bar',
+                ],
+                [
+                    'first' => 'Baz',
+                    'last' => 'Quux',
+                ],
+            ],
+        ]);
+        $this->getPrimaryField()->shouldReturn('first_name');
+        $this->getAdditionalFields()->shouldReturn(['last_name' => 'Quux']);
+    }
+
+    function it_can_parse_dot_notation_for_top_level_array_correctly()
+    {
+        $this->beConstructedWith('1.first_name', 'Baz', ['users', '*.first_name = first_name', '*.last_name = last_name'], [
+            [
+                'first_name' => 'Foo',
+                'last_name' => 'Bar',
+            ],
+            [
+                'first_name' => 'Baz',
+                'last_name' => 'Quux',
+            ],
+        ]);
+        $this->getPrimaryField()->shouldReturn('first_name');
+        $this->getAdditionalFields()->shouldReturn(['last_name' => 'Quux']);
+    }
+
     function it_returns_data_fields_correctly()
     {
         $this->beConstructedWith('first_name', 'Foo', ['users', 'first_name = firstName', 'middle_name', 'last_name => lastName', 'ignore:abc123 = user_id'], []);

--- a/spec/Felixkiss/UniqueWithValidator/RuleParserSpec.php
+++ b/spec/Felixkiss/UniqueWithValidator/RuleParserSpec.php
@@ -87,6 +87,18 @@ class RuleParserSpec extends ObjectBehavior
         $this->getIgnoreColumn()->shouldReturn('user_id');
     }
 
+    function it_can_parse_dot_notation_for_object_correctly()
+    {
+        $this->beConstructedWith('name.first', 'Foo', ['users', 'name.first = first_name', 'name.last = last_name'], [
+            'name' => [
+                'first' => 'Foo',
+                'last' => 'Bar',
+            ],
+        ]);
+        $this->getPrimaryField()->shouldReturn('first_name');
+        $this->getAdditionalFields()->shouldReturn(['last_name' => 'Bar']);
+    }
+
     function it_returns_data_fields_correctly()
     {
         $this->beConstructedWith('first_name', 'Foo', ['users', 'first_name = firstName', 'middle_name', 'last_name => lastName', 'ignore:abc123 = user_id'], []);

--- a/spec/Felixkiss/UniqueWithValidator/ValidatorSpec.php
+++ b/spec/Felixkiss/UniqueWithValidator/ValidatorSpec.php
@@ -254,6 +254,28 @@ class ValidatorSpec extends ObjectBehavior
         expect($this->validator->getMessageBag()->toArray())->toBe(['first_name' => [$expectedErrorMessage]]);
     }
 
+    function it_supports_dot_notation_for_an_object_in_rules()
+    {
+        $this->validateData(
+            ['name.first' => 'unique_with:users, name.first = first_name, name.last = last_name'],
+            [
+                'name' => [
+                    'first' => 'Foo',
+                    'last' => 'Bar',
+                ],
+            ]
+        );
+
+        $this->presenceVerifier->getCount(
+            'users',
+            'first_name',
+            'Foo',
+            null,
+            null,
+            ['last_name' => 'Bar']
+        )->shouldHaveBeenCalled();
+    }
+
     protected function validateData(array $rules = [], array $data = [])
     {
         $result = null;

--- a/spec/Felixkiss/UniqueWithValidator/ValidatorSpec.php
+++ b/spec/Felixkiss/UniqueWithValidator/ValidatorSpec.php
@@ -276,6 +276,43 @@ class ValidatorSpec extends ObjectBehavior
         )->shouldHaveBeenCalled();
     }
 
+    function it_supports_dot_notation_for_an_array_in_rules()
+    {
+        $this->validateData(
+            ['users.*.first' => 'unique_with:users, users.*.first = first_name, users.*.last = last_name'],
+            [
+                'users' => [
+                    [
+                        'first' => 'Foo',
+                        'last' => 'Bar',
+                    ],
+                    [
+                        'first' => 'Baz',
+                        'last' => 'Quux',
+                    ],
+                ],
+            ]
+        );
+
+        $this->presenceVerifier->getCount(
+            'users',
+            'first_name',
+            'Foo',
+            null,
+            null,
+            ['last_name' => 'Bar']
+        )->shouldHaveBeenCalled();
+
+        $this->presenceVerifier->getCount(
+            'users',
+            'first_name',
+            'Baz',
+            null,
+            null,
+            ['last_name' => 'Quux']
+        )->shouldHaveBeenCalled();
+    }
+
     protected function validateData(array $rules = [], array $data = [])
     {
         $result = null;

--- a/src/Felixkiss/UniqueWithValidator/RuleParser.php
+++ b/src/Felixkiss/UniqueWithValidator/RuleParser.php
@@ -1,5 +1,7 @@
 <?php namespace Felixkiss\UniqueWithValidator;
 
+use Illuminate\Support\Arr;
+
 class RuleParser
 {
     protected $table;
@@ -66,11 +68,11 @@ class RuleParser
                 continue;
             }
 
-            if (!array_key_exists($fieldName, $this->data)) {
+            if (!Arr::has($this->data, $fieldName)) {
                 continue;
             }
 
-            $this->additionalFields[$columnName] = $this->data[$fieldName];
+            $this->additionalFields[$columnName] = Arr::get($this->data, $fieldName);
         }
 
         $this->dataFields = array_values(array_unique($this->dataFields));


### PR DESCRIPTION
Closes #57 
Closes #64 
Closes #72 

More info: [Validating Arrays in the Laravel Validation docs](https://laravel.com/docs/validation#validating-arrays)

This PR adds support for:

## Dot access for nested arrays
```php
$data = [
    'name' => [
        'first' => 'Foo',
        'middle' => 'Bar',
        'last' => 'Baz',
    ],
];
$rules = [
    'name.first' => 'required|unique_with:users,name.first = first_name,name.middle = middle_name, name.last = last_name',
    'name.middle' => 'required',
    'name.last' => 'required',
];
$validator = Validator::make($data, $rules);
```

## Wildcard access to validate multiple elements in an array:
```php
$data = [
    'users' => [
        [
            'first' => 'Foo',
            'middle' => 'Bar',
            'last' => 'Baz',
        ],
        [
            'first' => 'Homer',
            'middle' => 'J.',
            'last' => 'Simpson',
        ],
        [
            'first' => 'Philip',
            'middle' => 'J.',
            'last' => 'Fry',
        ],
    ],
];
$rules = [
    'users.*.first' => 'required|unique_with:users,users.*.first = first_name, users.*.middle = middle_name, users.*.last = last_name',
    'users.*.middle' => 'required',
    'users.*.last' => 'required',
];
$validator = Validator::make($data, $rules);
```