### PR TITLE
add validator instance into parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 env:
   - LARAVEL_VERSION=5.2
   - LARAVEL_VERSION=5.3

--- a/spec/Felixkiss/UniqueWithValidator/ValidatorSpec.php
+++ b/spec/Felixkiss/UniqueWithValidator/ValidatorSpec.php
@@ -323,8 +323,15 @@ class ValidatorSpec extends ObjectBehavior
             $result = call_user_func_array([$this, 'validateUniqueWith'], func_get_args());
         }, $message);
         $factory->replacer('unique_with', function() {
-            $translator = $this->translator->getWrappedObject();
-            return call_user_func_array([$this, 'replaceUniqueWith'], array_merge(func_get_args(), [$translator]))->getWrappedObject();
+            $arguments = func_get_args();
+            if (sizeof($arguments) >= 5) {
+                $arguments[4] = $arguments[4]->getTranslator();
+            }
+            else {
+                $arguments[4] = $this->translator->getWrappedObject();
+            }
+
+            return call_user_func_array([$this, 'replaceUniqueWith'], $arguments)->getWrappedObject();
         });
         $factory->setPresenceVerifier($this->presenceVerifier->getWrappedObject());
 

--- a/src/Felixkiss/UniqueWithValidator/ServiceProvider.php
+++ b/src/Felixkiss/UniqueWithValidator/ServiceProvider.php
@@ -19,8 +19,19 @@ class ServiceProvider extends BaseServiceProvider
         $message = $this->app->translator->trans('uniquewith-validator::validation.unique_with');
         $this->app->validator->extend('unique_with', Validator::class . '@validateUniqueWith', $message);
         $this->app->validator->replacer('unique_with', function() {
-            $translator = $this->app->translator;
-            return call_user_func_array([new Validator, 'replaceUniqueWith'], array_merge(func_get_args(), [$translator]));
+            // Since 5.4.20, the validator is passed in as the 5th parameter.
+            // In order to preserve backwards compatibility, we check if the 
+            // validator is passed and use the validator's translator instead
+            // of getting it out of the container.
+            $arguments = func_get_args();
+            if (sizeof($arguments) >= 5) {
+                $arguments[4] = $arguments[4]->getTranslator();
+            }
+            else {
+                $arguments[4] = $this->app->translator;
+            }
+
+            return call_user_func_array([new Validator, 'replaceUniqueWith'], $arguments);
         });
     }
 

--- a/src/Felixkiss/UniqueWithValidator/Validator.php
+++ b/src/Felixkiss/UniqueWithValidator/Validator.php
@@ -25,7 +25,7 @@ class Validator
         ) == 0;
     }
 
-    public function replaceUniqueWith($message, $attribute, $rule, $parameters, $translator)
+    public function replaceUniqueWith($message, $attribute, $rule, $parameters, $validator, $translator)
     {
         $ruleParser = new RuleParser($attribute, null, $parameters);
         $fields = $ruleParser->getDataFields();

--- a/src/Felixkiss/UniqueWithValidator/Validator.php
+++ b/src/Felixkiss/UniqueWithValidator/Validator.php
@@ -25,7 +25,7 @@ class Validator
         ) == 0;
     }
 
-    public function replaceUniqueWith($message, $attribute, $rule, $parameters, $validator, $translator)
+    public function replaceUniqueWith($message, $attribute, $rule, $parameters, $translator)
     {
         $ruleParser = new RuleParser($attribute, null, $parameters);
         $fields = $ruleParser->getDataFields();


### PR DESCRIPTION
Closes #75 

`replaceUniqueWith` requires a sixth parameter to access to translator.