### PR TITLE
Update phpspec and phpspec2-expect dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,20 +10,14 @@
             "email": "felix@felixkiss.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/michaelperrin/phpspec2-expect"
-        }
-    ],
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "5.*",
         "illuminate/validation": "5.*"
     },
     "require-dev": {
-        "phpspec/phpspec": "^3.2",
-        "bossa/phpspec2-expect": "dev-phpspec-3.2"
+        "phpspec/phpspec": "^3.4",
+        "bossa/phpspec2-expect": "^2.3"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
The phpspec2-expect fork does not exist anymore and is not needed
anyway, since the original package was made compatible with phpspec
3.x