### PR TITLE
Add support for Laravel 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,42 @@
 language: php
+
 php:
-  - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
+  - 7.4snapshot
+
 env:
-  - LARAVEL_VERSION=5.2
-  - LARAVEL_VERSION=5.3
-  - LARAVEL_VERSION=5.4
+  - LARAVEL=5.5.*
+  - LARAVEL=5.6.*
+  - LARAVEL=5.7.*
+  - LARAVEL=5.8.*
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: 7.4snapshot
+  exclude:
+    - php: 7.0
+      env: LARAVEL=5.6.*
+    - php: 7.0
+      env: LARAVEL=5.7.*
+    - php: 7.0
+      env: LARAVEL=5.8.*
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_install:
-  - phpenv config-rm xdebug.ini || true
+  - composer require illuminate/support:$LARAVEL illuminate/validation:$LARAVEL --no-update --no-interaction --dev
 
-before_script:
-  - chmod +x scripts/change-laravel-version.sh && bash scripts/change-laravel-version.sh
-  - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+install:
+  - travis_retry composer install --no-suggest --no-interaction --prefer-dist --no-progress
 
-script: vendor/bin/phpspec run --format=pretty
+script:
+  - vendor/bin/phpspec run --format=pretty
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - travis_retry composer install --no-suggest --no-interaction --prefer-dist --no-progress
 
 script:
-  - vendor/bin/phpspec run --format=pretty
+  - vendor/bin/phpspec run --format=pretty --no-interaction
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: 7.4snapshot
+  exclude:
+    - php: 7.1
+      env: LARAVEL=^6.0
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - LARAVEL=5.6.*
   - LARAVEL=5.7.*
   - LARAVEL=5.8.*
+  - LARAVEL=^6.0
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
@@ -17,13 +16,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: 7.4snapshot
-  exclude:
-    - php: 7.0
-      env: LARAVEL=5.6.*
-    - php: 7.0
-      env: LARAVEL=5.7.*
-    - php: 7.0
-      env: LARAVEL=5.8.*
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1.3",
         "illuminate/support": "5.*|^6.0",
         "illuminate/validation": "5.*|^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": "^7.0",
         "illuminate/support": "5.*",
         "illuminate/validation": "5.*"
     },
     "require-dev": {
-        "phpspec/phpspec": "^3.4",
-        "bossa/phpspec2-expect": "^2.3"
+        "phpspec/phpspec": "^5.0",
+        "bossa/phpspec2-expect": "^3.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "5.*",
-        "illuminate/validation": "5.*"
+        "illuminate/support": "5.*|^6.0",
+        "illuminate/validation": "5.*|^6.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^5.0",

--- a/scripts/change-laravel-version.sh
+++ b/scripts/change-laravel-version.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-sed -i 's/\"illuminate\/support\"\: \"5\.\*\"/\"illuminate\/support\"\: \"'$LARAVEL_VERSION'\"/' composer.json
-sed -i 's/\"illuminate\/validation\"\: \"5\.\*\"/\"illuminate\/validation\"\: \"'$LARAVEL_VERSION'\"/' composer.json

--- a/spec/Felixkiss/UniqueWithValidator/ValidatorSpec.php
+++ b/spec/Felixkiss/UniqueWithValidator/ValidatorSpec.php
@@ -392,7 +392,7 @@ class ValidatorSpec extends ObjectBehavior
      */
     protected function trans(...$args)
     {
-        if (method_exists($this->translator, 'trans')) {
+        if (method_exists($this->translator->getWrappedObject(), 'trans')) {
             return $this->translator->trans(...$args);
         } else {
             return $this->translator->get(...$args);

--- a/src/Felixkiss/UniqueWithValidator/Validator.php
+++ b/src/Felixkiss/UniqueWithValidator/Validator.php
@@ -33,7 +33,11 @@ class Validator
         $ruleParser = new RuleParser($attribute, null, $parameters);
         $fields = $ruleParser->getDataFields();
 
-        $customAttributes = $translator->trans('validation.attributes');
+        if (method_exists($translator, 'trans')) {
+            $customAttributes = $translator->trans('validation.attributes');
+        } else {
+            $customAttributes = $translator->get('validation.attributes');
+        }
 
         // Check if translator has custom validation attributes for the fields
         $fields = array_map(function($field) use ($customAttributes) {


### PR DESCRIPTION
Closes #110

This PR adds support for the upcoming Laravel 6.0 release. We had to upgrade to phpspec 5 for development, because `illuminate/support@^6.0` requires `symfony/process@^4.2`.