### PR TITLE
Fix deprecated function

### DIFF
--- a/src/Felixkiss/UniqueWithValidator/ServiceProvider.php
+++ b/src/Felixkiss/UniqueWithValidator/ServiceProvider.php
@@ -16,7 +16,7 @@ class ServiceProvider extends BaseServiceProvider
             'uniquewith-validator'
         );
 
-        $message = $this->app->translator->trans('uniquewith-validator::validation.unique_with');
+        $message = $this->app->translator->get('uniquewith-validator::validation.unique_with');
         $this->app->validator->extend('unique_with', Validator::class . '@validateUniqueWith', $message);
         $this->app->validator->replacer('unique_with', function() {
             // Since 5.4.20, the validator is passed in as the 5th parameter.

--- a/src/Felixkiss/UniqueWithValidator/ServiceProvider.php
+++ b/src/Felixkiss/UniqueWithValidator/ServiceProvider.php
@@ -16,7 +16,12 @@ class ServiceProvider extends BaseServiceProvider
             'uniquewith-validator'
         );
 
-        $message = $this->app->translator->get('uniquewith-validator::validation.unique_with');
+        if (method_exists($this->app->translator, 'trans')) {
+            $message = $this->app->translator->trans('uniquewith-validator::validation.unique_with');
+        }
+        else {
+            $message = $this->app->translator->get('uniquewith-validator::validation.unique_with');
+        }
         $this->app->validator->extend('unique_with', Validator::class . '@validateUniqueWith', $message);
         $this->app->validator->replacer('unique_with', function() {
             // Since 5.4.20, the validator is passed in as the 5th parameter.


### PR DESCRIPTION
use `get` instead of `trans`, which is deprecated in Laravel 6 (see [https://laravel.com/docs/6.0/upgrade#trans-and-trans-choice](https://laravel.com/docs/6.0/upgrade#trans-and-trans-choice)
`get` was already available in Laravel 5, so it will work, too.