### PR TITLE
Laravel 7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 env:
   - LARAVEL=5.5.*
@@ -12,14 +12,17 @@ env:
   - LARAVEL=5.7.*
   - LARAVEL=5.8.*
   - LARAVEL=^6.0
+  - LARAVEL=^7.0
 
 matrix:
   fast_finish: true
   allow_failures:
-    - php: 7.4snapshot
+    - php: 7.4
   exclude:
     - php: 7.1
       env: LARAVEL=^6.0
+    - php: 7.1
+      env: LARAVEL=^7.0
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/support": "^5.6|^6.0|^7.0",
-        "illuminate/validation": "^5.6|^6.0|^7.0"
+        "illuminate/support": "^5.5|^6.0|^7.0",
+        "illuminate/validation": "^5.5|^6.0|^7.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/support": "5.*|^6.0",
-        "illuminate/validation": "5.*|^6.0"
+        "illuminate/support": "^5.6|^6.0|^7.0",
+        "illuminate/validation": "^5.6|^6.0|^7.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "illuminate/validation": "^5.5|^6.0|^7.0"
     },
     "require-dev": {
-        "phpspec/phpspec": "^5.0",
+        "phpspec/phpspec": "^5.0|^6.0",
         "bossa/phpspec2-expect": "^3.0"
     },
     "autoload": {


### PR DESCRIPTION
I also bumped the minimum `illuminate/*` version requirements to `^5.5` since that's what corresponds to the minimum PHP version requirement of `^7.1.3`